### PR TITLE
Add ESP8266 to library.properties architectures

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Read and debounce buttons and switches.
 paragraph=Read and debounce buttons and switches without delay or interrupts. React to button events with the onPressed() and onReleased() commands. Control debounce time with setDebounceTimeout(). This library sets each button up as input_pullup by default, allowing you to wire the button to any digital input and ground.
 category=Signal Input/Output
 url=https://github.com/alextaujenis/RBD_Button
-architectures=avr
+architectures=avr,esp8266


### PR DESCRIPTION
Eliminate the following warning for Adafruit Feather HUZZAH ESP8266:

```
WARNING: library RBD_Button claims to run on [avr] architecture(s) and may be incompatible with your current board which runs on [esp8266] architecture(s).
```
