### PR TITLE
allow specifying functions to do digitalRead and pinMode

### DIFF
--- a/src/RBD_Button.cpp
+++ b/src/RBD_Button.cpp
@@ -10,15 +10,21 @@
 namespace RBD {
   // input pullup enabled by default
   Button::Button(int pin)
-  : _pressed_debounce(), _released_debounce() {
+  : _pressed_debounce(), _released_debounce()
+  , _digitalRead(::digitalRead), _pinMode(::pinMode)
+  {
     _pin = pin;
     _inputPullup();
     setDebounceTimeout(_debounce_timeout);
   }
 
   // overloaded constructor to disable input pullup
-  Button::Button(int pin, bool input_pullup)
-  : _pressed_debounce(), _released_debounce() {
+  Button::Button(int pin, bool input_pullup,
+                 std::function<int(uint8_t)> digitalRead,
+                 std::function<void(uint8_t,uint8_t)> pinMode)
+  : _pressed_debounce(), _released_debounce()
+  , _digitalRead(digitalRead), _pinMode(pinMode)
+  {
     _pin = pin;
     if(input_pullup) {_inputPullup();}
     else {_disableInputPullup();}
@@ -32,7 +38,7 @@ namespace RBD {
   }
 
   bool Button::isPressed() {
-    _temp_reading = digitalRead(_pin);
+    _temp_reading = _digitalRead(_pin);
     if(_invert) {return !_temp_reading;}
     else {return _temp_reading;}
   }
@@ -83,10 +89,10 @@ namespace RBD {
   // private
 
   void Button::_inputPullup() {
-    pinMode(_pin, INPUT_PULLUP);
+    _pinMode(_pin, INPUT_PULLUP);
   }
 
   void Button::_disableInputPullup() {
-    pinMode(_pin, INPUT);
+    _pinMode(_pin, INPUT);
   }
 }

--- a/src/RBD_Button.h
+++ b/src/RBD_Button.h
@@ -8,12 +8,16 @@
 
 #include <Arduino.h>
 #include <RBD_Timer.h>  // https://github.com/alextaujenis/RBD_Timer
+#include <functional>
 
 namespace RBD {
   class Button {
     public:
       Button(int pin);                    // constructor: input pullup enabled by default
       Button(int pin, bool input_pullup); // overloaded constructor: flag available to disable input pullup
+      Button(int pin, bool input_pullup,
+             std::function<int(uint8_t)> digitalRead=::digitalRead,
+             std::function<void(uint8_t, uint8_t)> pinMode=::pinMode);
       void setDebounceTimeout(unsigned long value);
       bool isPressed();
       bool isReleased();
@@ -31,6 +35,8 @@ namespace RBD {
       void _disableInputPullup();
       Timer _pressed_debounce;
       Timer _released_debounce;
+      std::function<int(uint8_t)> _digitalRead;
+      std::function<void(uint8_t, uint8_t)> _pinMode;
   };
 }
 #endif


### PR DESCRIPTION
We are using this library with a GPIO extender, which has to be implemented a bit differently.  I think this is a non-breaking change that allows this library to be used in such (and other) applications which have non-conformant ways of adressing DI's 

Thanks,
Hoppy